### PR TITLE
Lock booking conf post start

### DIFF
--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -15,7 +15,7 @@ class BookingsController < ApplicationController
 
   def confirm
     return unless user_is_host?
-    return if cancelled?(@booking)
+    return if cancelled?(@booking) || @booking.started?
 
     @booking.confirmation_status = 'confirmed'
     redirect_to booking_path(@booking) if @booking.save!
@@ -23,7 +23,7 @@ class BookingsController < ApplicationController
 
   def decline
     return unless user_is_host?
-    return if cancelled?(@booking)
+    return if cancelled?(@booking) || @booking.started?
 
     @booking.confirmation_status = 'declined'
     redirect_to booking_path(@booking) if @booking.save!
@@ -31,6 +31,7 @@ class BookingsController < ApplicationController
 
   def cancel
     return unless current_user == @booking.user
+    return if @booking.started?
 
     @booking.confirmation_status = 'cancelled'
     redirect_to booking_path(@booking) if @booking.save

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -12,4 +12,8 @@ class Booking < ApplicationRecord
     duration = (Time.parse(end_time.to_s) - Time.parse(start_time.to_s)) / 3600
     (duration * nap_space.cost_per_hr).round(2)
   end
+
+  def started?
+    Time.parse(DateTime.now.to_s) > Time.parse(start_time.to_s)
+  end
 end

--- a/app/views/bookings/index.html.erb
+++ b/app/views/bookings/index.html.erb
@@ -30,13 +30,13 @@
       <hr>
       <p><strong><em><%= booking.confirmation_status.capitalize %></em></strong></p>
 
-      <% if booking.confirmation_status == 'requested'  %>
+      <% if (booking.confirmation_status == 'requested' && !booking.started?)  %>
         <% if (booking.nap_space.user == current_user) %>
           <%= link_to "Confirm", booking_confirm_path(booking), class: "btn btn-primary mt-2" %>
           <%= link_to "Decline", booking_decline_path(booking), class: "btn btn-warning  mt-2" %>
         <% end %>
       <% end %>
-      <% unless booking.confirmation_status == 'cancelled' %>
+      <% unless (booking.confirmation_status == 'cancelled' || booking.started?) %>
         <% if booking.user == current_user %>
           <%= link_to "Cancel", booking_cancel_path(booking), class: "btn btn-danger  mt-2" %>
         <% end %>

--- a/app/views/bookings/index.html.erb
+++ b/app/views/bookings/index.html.erb
@@ -30,11 +30,9 @@
       <hr>
       <p><strong><em><%= booking.confirmation_status.capitalize %></em></strong></p>
 
-      <% if (booking.confirmation_status == 'requested' && !booking.started?)  %>
-        <% if (booking.nap_space.user == current_user) %>
-          <%= link_to "Confirm", booking_confirm_path(booking), class: "btn btn-primary mt-2" %>
-          <%= link_to "Decline", booking_decline_path(booking), class: "btn btn-warning  mt-2" %>
-        <% end %>
+      <% if (booking.confirmation_status == 'requested' && !booking.started? && booking.nap_space.user == current_user)  %>
+        <%= link_to "Confirm", booking_confirm_path(booking), class: "btn btn-primary mt-2" %>
+        <%= link_to "Decline", booking_decline_path(booking), class: "btn btn-warning  mt-2" %>
       <% end %>
       <% unless (booking.confirmation_status == 'cancelled' || booking.started?) %>
         <% if booking.user == current_user %>


### PR DESCRIPTION
Bookings can no longer have their confirmation_status updated after they have started. Implemented end to end.