### PR TITLE
Style updates to all cards

### DIFF
--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -8,6 +8,7 @@ class BookingsController < ApplicationController
     @bookings = current_user.bookings.order(:start_time).reject(&:ended?)
     @bookings_to_approve = current_user.nap_spaces.map(&:bookings).flatten.reject(&:started?)
     @bookings_past = current_user.bookings.select(&:ended?).select(&:confirmed?)
+    @bookings_past_host = current_user.nap_spaces.map(&:bookings).flatten.select(&:ended?).select(&:confirmed?)
     @review = Review.new
   end
 

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -63,7 +63,7 @@ class Booking < ApplicationRecord
   end
 
   def start_time_formatted
-    start_time.strftime("%I:%M%p, %m/%d/%Y")
+    start_time.to_fs(:long_ordinal)
   end
 
   private

--- a/app/views/bookings/_booking.html.erb
+++ b/app/views/bookings/_booking.html.erb
@@ -46,6 +46,18 @@
                 </div>
               <% end %>
             <% end %>
+
+            <% if tab == "past-host" && booking.review %>
+              <div class="card rounded border-0 shadow overflow-hidden pt-2" style="width: 18rem;">
+                <div class="card-body">
+                  <p class="card-text">
+                    <% booking.review.rating.times do %>
+                      <i class="fa fa-star text-warning" aria-hidden="true" ></i>
+                    <% end %></p>
+                  <p class="card-text"><em><%= booking.review.content %></em></p>
+                </div>
+              </div>
+            <% end %>
           </ul>
         </div>
       </div>

--- a/app/views/bookings/_booking.html.erb
+++ b/app/views/bookings/_booking.html.erb
@@ -1,21 +1,51 @@
-<%# NOT CURRENTLY USED ANYWHERE - COULD BE NICE IN FUTURE TO KEEP CODE DRY %>
-
 <div class="col-lg-4 col-md-6 mb-4 pb-22">
   <div class="card blog blog-primary rounded border-0 shadow overflow-hidden">
     <div class="position-relative">
-      <%= cl_image_tag booking.nap_space.image_url.key, class: "card-img-top", height: 300 %>
-      <div class="overlay rounded-top"></div>
+      <h2 class="card-header bg-<%= booking.confirmation_status_styling %> text-light text-center"><%= booking.confirmation_status.capitalize %></h2>
+      <%= cl_image_tag booking.nap_space.image_url.key, class: "card-img rounded-0", height: 300 %>
+      <div class="overlay"></div>
       <div class="card-body content">
-        <h3 class="card-title title text-dark">  <%= booking.nap_space.description %></h3>
+        <h3 class="card-title title text-dark">
+          <%= link_to booking.nap_space.description, nap_space_path(booking.nap_space), class: "link-text-dark" %>
+        </h3>
         <div class="post-meta d-flex justify-content-between mt-3">
           <ul class="list-unstyled mb-0">
             <li class="list-inline-item me-2 mb-0">
               <p class="text-muted readmore"> <%= booking.nap_space.address %></p>
             </li>
-            <li class=" text-muted mb-2"><%= "Start Time: $#{booking.start_time}" %></li>
-            <li class=" text-muted mb-2"><%= "Duration: $#{booking.duration_hours}hours" %></li>
-            <li class=" text-muted mb-2"><%= "Cost: $#{booking.total_cost}" %></li>
-            <li class=" text-muted mb-2"><%= booking.confirmation_status %></li>
+            <li class=" text-muted mb-2"><%= "Start Time: #{booking.start_time_formatted}" %></li>
+            <li class=" text-muted mb-2"><%= "Duration: #{booking.duration_display}" %></li>
+            <li class=" text-muted mb-2"><%= "Total Cost: $#{booking.total_cost}" %></li>
+
+            <%# Cancel button for user that booked %>
+            <% if booking.confirmation_status != 'cancelled' && booking.user == current_user && tab == "upcoming"%>
+              <%= link_to "Cancel", booking_cancel_path(booking), class: "btn btn-danger  mt-2" %>
+            <% end %>
+
+            <%# Confirm/decline/cancel buttons for Host %>
+            <% if (booking.confirmation_status == 'requested' && !booking.started? && tab == "upcoming-host")  %>
+              <%= link_to "Confirm", booking_confirm_path(booking), class: "btn btn-primary mt-2" %>
+              <%= link_to "Decline", booking_decline_path(booking), class: "btn btn-warning  mt-2" %>
+            <% elsif booking.confirmation_status == 'confirmed' && !booking.started? && tab == "upcoming-host" %>
+              <%= link_to "Cancel", booking_cancel_path(booking), class: "btn btn-danger  mt-2" %>
+            <% end %>
+
+            <%# Reviews for past naps %>
+            <% if tab == "past" %>
+              <% unless booking.review %>
+                <%= link_to "Leave a review", new_booking_review_path(booking), class: "btn btn-primary  mt-2"  %>
+              <% else %>
+                <div class="card rounded border-0 shadow overflow-hidden pt-2" style="width: 18rem;">
+                  <div class="card-body">
+                    <p class="card-text">
+                      <% booking.review.rating.times do %>
+                        <i class="fa fa-star text-warning" aria-hidden="true" ></i>
+                      <% end %></p>
+                    <p class="card-text"><em><%= booking.review.content %></em></p>
+                  </div>
+                </div>
+              <% end %>
+            <% end %>
           </ul>
         </div>
       </div>

--- a/app/views/bookings/_booking.html.erb
+++ b/app/views/bookings/_booking.html.erb
@@ -18,8 +18,10 @@
             <li class=" text-muted mb-2"><%= "Total Cost: $#{booking.total_cost}" %></li>
 
             <%# Cancel button for user that booked %>
-            <% if booking.confirmation_status != 'cancelled' && booking.user == current_user && tab == "upcoming"%>
-              <%= link_to "Cancel", booking_cancel_path(booking), class: "btn btn-danger  mt-2" %>
+            <% if booking.user == current_user && tab == "upcoming" %>
+              <% unless booking.confirmation_status == 'cancelled' || booking.confirmation_status == 'declined' %>
+                <%= link_to "Cancel", booking_cancel_path(booking), class: "btn btn-danger  mt-2" %>
+              <% end %>
             <% end %>
 
             <%# Confirm/decline/cancel buttons for Host %>
@@ -47,6 +49,7 @@
               <% end %>
             <% end %>
 
+            <%# Reviews for past host bookings %>
             <% if tab == "past-host" && booking.review %>
               <div class="card rounded border-0 shadow overflow-hidden pt-2" style="width: 18rem;">
                 <div class="card-body">

--- a/app/views/bookings/index.html.erb
+++ b/app/views/bookings/index.html.erb
@@ -11,33 +11,7 @@
             <p class="text-muted readmore"> You have no upcoming bookings.</p>
           <% end %>
           <% @bookings.each do |booking| %>
-            <div class="col-lg-4 col-md-6 mb-4 pb-22">
-              <div class="card blog blog-primary rounded border-0 shadow overflow-hidden">
-                <div class="position-relative">
-                  <h2 class="card-header bg-<%= booking.confirmation_status_styling %> text-light text-center"><%= booking.confirmation_status.capitalize %></h2>
-                  <%= cl_image_tag booking.nap_space.image_url.key, height: 300 %>
-                  <div class="overlay"></div>
-                  <div class="card-body content">
-                    <h3 class="card-title title text-dark">
-                      <%= link_to booking.nap_space.description, nap_space_path(booking.nap_space), class: "link-text-dark" %>
-                    </h3>
-                    <div class="post-meta d-flex justify-content-between mt-3">
-                      <ul class="list-unstyled mb-0">
-                        <li class="list-inline-item me-2 mb-0">
-                          <p class="text-muted readmore"> <%= booking.nap_space.address %></p>
-                        </li>
-                        <li class=" text-muted mb-2"><%= "Start Time: #{booking.start_time_formatted}" %></li>
-                        <li class=" text-muted mb-2"><%= "Duration: #{booking.duration_display}" %></li>
-                        <li class=" text-muted mb-2"><%= "Total Cost: $#{booking.total_cost}" %></li>
-                        <% unless booking.confirmation_status == 'cancelled' %>
-                          <%= link_to "Cancel", booking_cancel_path(booking), class: "btn btn-danger  mt-2" %>
-                        <% end %>
-                      </ul>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
+            <%= render "booking", booking: booking, tab: "upcoming" %>
           <% end %>
         </div>
       </div>
@@ -58,36 +32,7 @@
             <p class="text-muted readmore"> You have no bookings to approve.</p>
           <% end %>
           <% @bookings_to_approve.each do |booking| %>
-            <div class="col-lg-4 col-md-6 mb-4 pb-22">
-              <div class="card blog blog-primary rounded border-0 shadow overflow-hidden">
-                <div class="position-relative">
-                  <%= cl_image_tag booking.nap_space.image_url.key, class: "card-img-top", height: 300 %>
-                  <div class="overlay rounded-top"></div>
-                  <div class="card-body content">
-                    <h3 class="card-title title text-dark">
-                      <%= link_to booking.nap_space.description, nap_space_path(booking.nap_space), class: "link-text-dark" %>
-                    </h3>
-                    <div class="post-meta d-flex justify-content-between mt-3">
-                      <ul class="list-unstyled mb-0">
-                        <li class="list-inline-item me-2 mb-0">
-                          <p class="text-muted readmore"> <%= booking.nap_space.address %></p>
-                        </li>
-                        <li class=" text-muted mb-2"><%= "Start Time: #{booking.start_time_formatted}" %></li>
-                        <li class=" text-muted mb-2"><%= "Duration: #{booking.duration_display}" %></li>
-                        <li class=" text-muted mb-2"><%= "Cost: $#{booking.total_cost}" %></li>
-                        <li class="mb-2">
-                          <span class="badge bg-<%= booking.confirmation_status_styling %>"><%= booking.confirmation_status %></span>
-                        </li>
-                        <% if (booking.confirmation_status == 'requested' && !booking.started?)  %>
-                          <%= link_to "Confirm", booking_confirm_path(booking), class: "btn btn-primary mt-2" %>
-                          <%= link_to "Decline", booking_decline_path(booking), class: "btn btn-warning  mt-2" %>
-                        <% end %>
-                      </ul>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
+            <%= render "booking", booking: booking, tab: "upcoming-host" %>
           <% end %>
         </div>
       </div>
@@ -108,52 +53,10 @@
             <p class="text-muted readmore"> You have no past bookings.</p>
           <% end %>
           <% @bookings_past.each do |booking| %>
-            <div class="col-lg-4 col-md-6 mb-4 pb-22">
-              <div class="card blog blog-primary rounded border-0 shadow overflow-hidden">
-                <div class="position-relative">
-                  <%= cl_image_tag booking.nap_space.image_url.key, class: "card-img-top", height: 300 %>
-                  <div class="overlay rounded-top"></div>
-                  <div class="card-body content">
-                    <h3 class="card-title title text-dark">
-                      <%= link_to booking.nap_space.description, nap_space_path(booking.nap_space), class: "link-text-dark" %>
-                    </h3>
-                    <div class="post-meta d-flex justify-content-between mt-3">
-                      <ul class="list-unstyled mb-0">
-                        <li class="list-inline-item me-2 mb-0">
-                          <p class="text-muted readmore"> <%= booking.nap_space.address %></p>
-                        </li>
-                        <li class=" text-muted mb-2"><%= "Start Time: #{booking.start_time_formatted}" %></li>
-                        <li class=" text-muted mb-2"><%= "Duration: #{booking.duration_display}" %></li>
-                        <li class=" text-muted mb-2"><%= "Cost: $#{booking.total_cost}" %></li>
-                        <li class="mb-2">
-                          <span class="badge bg-<%= booking.confirmation_status_styling %>"><%= booking.confirmation_status %></span>
-                        </li>
-                        <% unless booking.review %>
-                          <%= link_to "Leave a review", new_booking_review_path(booking), class: "btn btn-primary  mt-2"  %>
-                        <% else %>
-                          <div class="card rounded border-0 shadow overflow-hidden pt-2" style="width: 18rem;">
-                            <div class="card-body">
-                              <p class="card-text">
-                                <% booking.review.rating.times do %>
-                                  <i class="fa fa-star text-warning" aria-hidden="true" ></i>
-                                <% end %></p>
-                              <p class="card-text"><em><%= booking.review.content %></em></p>
-                            </div>
-                          </div>
-                        <% end %>
-                      </ul>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
+            <%= render "booking", booking: booking, tab: "past" %>
           <% end %>
         </div>
       </div>
     </div>
   </div>
 </div>
-<br>
-<br>
-<br>
-<br>

--- a/app/views/bookings/index.html.erb
+++ b/app/views/bookings/index.html.erb
@@ -14,8 +14,9 @@
             <div class="col-lg-4 col-md-6 mb-4 pb-22">
               <div class="card blog blog-primary rounded border-0 shadow overflow-hidden">
                 <div class="position-relative">
-                  <%= cl_image_tag booking.nap_space.image_url.key, class: "card-img-top", height: 300 %>
-                  <div class="overlay rounded-top"></div>
+                  <h2 class="card-header bg-<%= booking.confirmation_status_styling %> text-light text-center"><%= booking.confirmation_status.capitalize %></h2>
+                  <%= cl_image_tag booking.nap_space.image_url.key, height: 300 %>
+                  <div class="overlay"></div>
                   <div class="card-body content">
                     <h3 class="card-title title text-dark">
                       <%= link_to booking.nap_space.description, nap_space_path(booking.nap_space), class: "link-text-dark" %>
@@ -27,10 +28,7 @@
                         </li>
                         <li class=" text-muted mb-2"><%= "Start Time: #{booking.start_time_formatted}" %></li>
                         <li class=" text-muted mb-2"><%= "Duration: #{booking.duration_display}" %></li>
-                        <li class=" text-muted mb-2"><%= "Cost: $#{booking.total_cost}" %></li>
-                        <li class="mb-2">
-                          <span class="badge bg-<%= booking.confirmation_status_styling %>"><%= booking.confirmation_status %></span>
-                        </li>
+                        <li class=" text-muted mb-2"><%= "Total Cost: $#{booking.total_cost}" %></li>
                         <% unless booking.confirmation_status == 'cancelled' %>
                           <%= link_to "Cancel", booking_cancel_path(booking), class: "btn btn-danger  mt-2" %>
                         <% end %>
@@ -133,7 +131,15 @@
                         <% unless booking.review %>
                           <%= link_to "Leave a review", new_booking_review_path(booking), class: "btn btn-primary  mt-2"  %>
                         <% else %>
-                          <p>Thank you for your review!</p>
+                          <div class="card rounded border-0 shadow overflow-hidden pt-2" style="width: 18rem;">
+                            <div class="card-body">
+                              <p class="card-text">
+                                <% booking.review.rating.times do %>
+                                  <i class="fa fa-star text-warning" aria-hidden="true" ></i>
+                                <% end %></p>
+                              <p class="card-text"><em><%= booking.review.content %></em></p>
+                            </div>
+                          </div>
                         <% end %>
                       </ul>
                     </div>

--- a/app/views/bookings/index.html.erb
+++ b/app/views/bookings/index.html.erb
@@ -8,7 +8,7 @@
       <div class="accordion-body">
         <div class="row">
           <% if @bookings.empty? %>
-            <p class="text-muted readmore"> You have no upcoming bookings.</p>
+            <p class="text-muted readmore"> You have no upcoming naps.</p>
           <% end %>
           <% @bookings.each do |booking| %>
             <%= render "booking", booking: booking, tab: "upcoming" %>
@@ -43,14 +43,14 @@
   <div class="accordion-item">
     <h2 class="accordion-header" id="panelsStayOpen-headingThree">
       <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#panelsStayOpen-collapseThree" aria-expanded="true" aria-controls="panelsStayOpen-collapseThree">
-        Your Past Bookings
+        Your Past Naps
       </button>
     </h2>
     <div id="panelsStayOpen-collapseThree" class="accordion-collapse collapse show " aria-labelledby="panelsStayOpen-headingThree">
       <div class="accordion-body">
         <div class="row">
           <% if @bookings_past.empty? %>
-            <p class="text-muted readmore"> You have no past bookings.</p>
+            <p class="text-muted readmore"> You have no past naps.</p>
           <% end %>
           <% @bookings_past.each do |booking| %>
             <%= render "booking", booking: booking, tab: "past" %>

--- a/app/views/bookings/index.html.erb
+++ b/app/views/bookings/index.html.erb
@@ -59,4 +59,25 @@
       </div>
     </div>
   </div>
+
+  <%# display all past host bookings %>
+  <div class="accordion-item">
+    <h2 class="accordion-header" id="panelsStayOpen-headingFour">
+      <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#panelsStayOpen-collapseFour" aria-expanded="true" aria-controls="panelsStayOpen-collapseThree">
+        Your Past Host Bookings
+      </button>
+    </h2>
+    <div id="panelsStayOpen-collapseFour" class="accordion-collapse collapse show " aria-labelledby="panelsStayOpen-headingFour">
+      <div class="accordion-body">
+        <div class="row">
+          <% if @bookings_past_host.empty? %>
+            <p class="text-muted readmore"> You have no past host bookings.</p>
+          <% end %>
+          <% @bookings_past_host.each do |booking| %>
+            <%= render "booking", booking: booking, tab: "past-host" %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>

--- a/app/views/bookings/index.html.erb
+++ b/app/views/bookings/index.html.erb
@@ -19,25 +19,27 @@
   </div>
 
   <%# display upcoming host bookings %>
-  <div class="accordion-item">
-    <h2 class="accordion-header" id="panelsStayOpen-headingTwo">
-      <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#panelsStayOpen-collapseTwo" aria-expanded="true" aria-controls="panelsStayOpen-collapseTwo">
-        My Upcoming Host Bookings
-      </button>
-    </h2>
-    <div id="panelsStayOpen-collapseTwo" class="accordion-collapse collapse show" aria-labelledby="panelsStayOpen-headingTwo">
-      <div class="accordion-body">
-        <div class="row">
-          <% if @bookings_to_approve.empty? %>
-            <p class="text-muted readmore"> You have no bookings to approve.</p>
-          <% end %>
-          <% @bookings_to_approve.each do |booking| %>
-            <%= render "booking", booking: booking, tab: "upcoming-host" %>
-          <% end %>
+  <% unless current_user.nap_spaces.empty? %>
+    <div class="accordion-item">
+      <h2 class="accordion-header" id="panelsStayOpen-headingTwo">
+        <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#panelsStayOpen-collapseTwo" aria-expanded="true" aria-controls="panelsStayOpen-collapseTwo">
+          My Upcoming Host Bookings
+        </button>
+      </h2>
+      <div id="panelsStayOpen-collapseTwo" class="accordion-collapse collapse show" aria-labelledby="panelsStayOpen-headingTwo">
+        <div class="accordion-body">
+          <div class="row">
+            <% if @bookings_to_approve.empty? %>
+              <p class="text-muted readmore"> You have no bookings to approve.</p>
+            <% end %>
+            <% @bookings_to_approve.each do |booking| %>
+              <%= render "booking", booking: booking, tab: "upcoming-host" %>
+            <% end %>
+          </div>
         </div>
       </div>
     </div>
-  </div>
+  <% end %>
 
   <%# display all past bookings %>
   <div class="accordion-item">
@@ -61,23 +63,22 @@
   </div>
 
   <%# display all past host bookings %>
-  <div class="accordion-item">
-    <h2 class="accordion-header" id="panelsStayOpen-headingFour">
-      <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#panelsStayOpen-collapseFour" aria-expanded="true" aria-controls="panelsStayOpen-collapseThree">
-        Your Past Host Bookings
-      </button>
-    </h2>
-    <div id="panelsStayOpen-collapseFour" class="accordion-collapse collapse show " aria-labelledby="panelsStayOpen-headingFour">
-      <div class="accordion-body">
-        <div class="row">
-          <% if @bookings_past_host.empty? %>
-            <p class="text-muted readmore"> You have no past host bookings.</p>
-          <% end %>
-          <% @bookings_past_host.each do |booking| %>
-            <%= render "booking", booking: booking, tab: "past-host" %>
-          <% end %>
+  <% unless @bookings_past_host.empty? %>
+    <div class="accordion-item">
+      <h2 class="accordion-header" id="panelsStayOpen-headingFour">
+        <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#panelsStayOpen-collapseFour" aria-expanded="true" aria-controls="panelsStayOpen-collapseThree">
+          Your Past Host Bookings
+        </button>
+      </h2>
+      <div id="panelsStayOpen-collapseFour" class="accordion-collapse collapse show " aria-labelledby="panelsStayOpen-headingFour">
+        <div class="accordion-body">
+          <div class="row">
+            <% @bookings_past_host.each do |booking| %>
+              <%= render "booking", booking: booking, tab: "past-host" %>
+            <% end %>
+          </div>
         </div>
       </div>
     </div>
-  </div>
+  <% end %>
 </div>

--- a/app/views/nap_spaces/_nap_space.html.erb
+++ b/app/views/nap_spaces/_nap_space.html.erb
@@ -10,7 +10,7 @@
             <li class="list-inline-item me-2 mb-0 card-body ">
               <h5 class="title"> Address</h5>
               <p class="readmore"><%= nap_space.address %></p>
-              <h5 class="title"> Cost per Hour</h5>
+              <h5 class="title"> Hourly rate:</h5>
               <p class="readmore"> $<%= nap_space.cost_per_hr %></p>
             </li>
           </ul>

--- a/app/views/nap_spaces/_nap_space.html.erb
+++ b/app/views/nap_spaces/_nap_space.html.erb
@@ -6,7 +6,7 @@
         <div class="card-body content">
           <h3 class="card-title title text-dark">  <%= nap_space.description %></h3>
           <ul class="list-unstyled mb-0">
-            <li class="list-inline-item me-2 mb-0 "><%= cl_image_tag nap_space.image_url.key, class: "thumbpost" %></li>
+            <li class="list-inline-item me-2 mb-0 "><%= cl_image_tag nap_space.image_url.key, class: "thumbpost rounded" %></li>
             <li class="list-inline-item me-2 mb-0 card-body ">
               <h5 class="title"> Address</h5>
               <p class="readmore"><%= nap_space.address %></p>

--- a/app/views/nap_spaces/_nap_space.html.erb
+++ b/app/views/nap_spaces/_nap_space.html.erb
@@ -12,7 +12,6 @@
               <p class="readmore"><%= nap_space.address %></p>
               <h5 class="title"> Cost per Hour</h5>
               <p class="readmore"> $<%= nap_space.cost_per_hr %></p>
-              <p class="text-muted"> listing was updated <%= nap_space.updated_at%></p>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
- User will not see host tabs if they do not have any napspaces or past host bookings
<img width="931" alt="image" src="https://user-images.githubusercontent.com/68765634/218951589-0e7ca112-604c-4bc4-9941-c86a2470a20a.png">

- updated styling of bookings card to have confirmation status in the header rather than badge
<img width="916" alt="image" src="https://user-images.githubusercontent.com/68765634/218951743-17aaae92-fac6-4179-a362-c150d8678271.png">

- consolidated booking card in one component 
- updated time/date format
- other minor style tweaks
