### PR TITLE
Link to nap_space show from map popover

### DIFF
--- a/app/views/nap_spaces/_popup.html.erb
+++ b/app/views/nap_spaces/_popup.html.erb
@@ -1,2 +1,5 @@
 <h5><%= nap_space.description %></h5>
 <p><%= nap_space.address %></p>
+<% if current_page?(nap_spaces_path) %>
+  <%= link_to "View details", nap_space_path(nap_space) %>
+<% end %>


### PR DESCRIPTION
- added a link to "view details" of napspace from mapbox popover
- should only display from index page
<img width="625" alt="image" src="https://user-images.githubusercontent.com/68765634/218971200-b06697fd-f22e-4218-aed3-055267dc4981.png">
